### PR TITLE
Add saveSystemPromptToAgentsMd to persist system prompt in Codex AGENTS.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
+# Save system prompt to Codex AGENTS.md
+
+This package now includes a helper to persist a user's system prompt into the Codex CLI folder when Codex is in use.
+
+- Function: `saveSystemPromptToAgentsMd(systemPrompt: string)`
+- Behavior: Writes the provided system prompt to `~/.codex/AGENTS.md` (or `$CODEX_HOME/AGENTS.md`) only if the Codex folder exists.
+
+Usage example (TypeScript):
+
+```
+import { saveSystemPromptToAgentsMd } from './src';
+
+// Call this after updating the user's settings
+saveSystemPromptToAgentsMd(settings.systemPrompt);
+```
+
+Notes:
+- Codex detection is based on existence of the `~/.codex` directory (or `$CODEX_HOME`).
+- The file is overwritten on each call to reflect the latest system prompt.
 This is a test repo for mathimatical operations.

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -1,0 +1,35 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+/**
+ * Save the provided system prompt into AGENTS.md inside the Codex folder.
+ *
+ * Behavior:
+ * - Detect Codex home as `$CODEX_HOME` or `~/.codex`.
+ * - Only writes if the Codex folder exists (signals Codex is in use).
+ * - Overwrites `AGENTS.md` with the given `systemPrompt` string.
+ *
+ * @param systemPrompt The system prompt text to persist.
+ * @returns true if written, false if skipped (Codex not detected).
+ */
+export function saveSystemPromptToAgentsMd(systemPrompt: string): boolean {
+  const codexHome = process.env.CODEX_HOME || path.join(os.homedir(), '.codex');
+
+  try {
+    const stats = fs.statSync(codexHome);
+    if (!stats.isDirectory()) return false;
+  } catch {
+    // Codex folder not found: consider not using Codex, skip writing.
+    return false;
+  }
+
+  const agentsPath = path.join(codexHome, 'AGENTS.md');
+
+  // Write synchronously to ensure durability at call time.
+  fs.writeFileSync(agentsPath, systemPrompt ?? '', { encoding: 'utf8' });
+  return true;
+}
+
+export default saveSystemPromptToAgentsMd;
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,2 @@
+export { saveSystemPromptToAgentsMd } from './agents';
+


### PR DESCRIPTION
## Summary
- Introduces a new utility function `saveSystemPromptToAgentsMd` to save a user's system prompt into the Codex CLI folder
- Detects Codex home directory via `$CODEX_HOME` or defaults to `~/.codex`
- Writes the system prompt to `AGENTS.md` only if the Codex folder exists
- Adds usage example and documentation in README

## Changes

### Core Functionality
- **src/agents.ts**: New module exporting `saveSystemPromptToAgentsMd` function
  - Checks for Codex directory presence
  - Overwrites `AGENTS.md` with the provided system prompt synchronously
  - Returns boolean indicating success or skip

### Exports
- **src/index.ts**: Re-exports `saveSystemPromptToAgentsMd` for external usage

### Documentation
- **README.md**: Added detailed description, usage example, and notes about the new function

## Test plan
- Verify that calling `saveSystemPromptToAgentsMd` writes the system prompt to the correct file when Codex folder exists
- Confirm function returns false and does not write when Codex folder is absent
- Check README instructions for clarity and correctness

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/f178767d-fac1-4fbd-a738-7367d087b247